### PR TITLE
Readme show how to register v2 of the hooks instead of v1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ This code is most frequently put in a custom test runner's `onStart()` method:
 ```java
 public final class MyTestRunner extends AndroidJUnitRunner {
   @Override public void onStart() {
-    RxJavaPlugins.setInitComputationSchedulerHandler(
-        Rx2Idler.create("RxJava 2.x Computation Scheduler"));
+    RxJavaPlugins.getInstance().registerSchedulersHook(RxIdler.hooks());
     // etc...
     
     super.onStart();


### PR DESCRIPTION
There is a small issue with the README.md as it is showing how to register v2 of the hooks in the section for the v1.
The existing code snippet might be just intended to show general (v2) use but it still feels like belonging to the v1 part. 