### PR TITLE
Add proguard information into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,23 +53,6 @@ Espresso.registerIdlingResources(wrapped);
 // Use 'wrapped' now instead of 'myScheduler'...
 ```
 
-Proguard
---------
-
-If you use Proguard on Espresso test builds, you may need to add the following rules into your proguard configuration.
-
-
-RxJava 2.x:
-```
--keep public class io.reactivex.plugins.RxJavaPlugins { *; }
--keep public class io.reactivex.disposables.CompositeDisposable { *; }
-```
-
-RxJava 1.x:
-```
--keep public class rx.plugins.RxJavaPlugins { *; }
--keep public class rx.subscriptions.CompositeSubscription { *; }
-```
 
 Download
 --------
@@ -91,6 +74,25 @@ dependencies {
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
+
+
+ProGuard
+--------
+
+If you use ProGuard on Espresso test builds, you may need to add the following rules into your ProGuard configuration.
+
+
+RxJava 2.x:
+```
+-keep class io.reactivex.plugins.RxJavaPlugins { *; }
+-keep class io.reactivex.disposables.CompositeDisposable { *; }
+```
+
+RxJava 1.x:
+```
+-keep class rx.plugins.RxJavaPlugins { *; }
+-keep class rx.subscriptions.CompositeSubscription { *; }
+```
 
 
 License

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ Espresso.registerIdlingResources(wrapped);
 // Use 'wrapped' now instead of 'myScheduler'...
 ```
 
+Proguard
+--------
+
+If you use Proguard on Espresso test builds, you may need to add the following rules into your proguard configuration.
+
+
+RxJava 2.x:
+```
+-keep public class io.reactivex.plugins.RxJavaPlugins { *; }
+-keep public class io.reactivex.disposables.CompositeDisposable { *; }
+```
+
+RxJava 1.x:
+```
+-keep public class rx.plugins.RxJavaPlugins { *; }
+-keep public class rx.subscriptions.CompositeSubscription { *; }
+```
 
 Download
 --------


### PR DESCRIPTION
Added Proguard configuration information into README. 

When proguard is enabled in Espresso tests, some constructors and some methods are missing from RxJava since proguard optimizations remove unused methods. So in our project, we added the following rules. 

I think the rules can be more strict but in Espresso tests, they are fine if they are not that strict. 

**Note:** Libraries can include `consumerProguardFiles` but they are included in production version of the app so I thought I shouldn't add one. Readme seems enough. 

Thanks.