### PR TITLE
Make it clearer that in Rx2, you need to register idling resources for each scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Set the wrapping functions as the delegate for handling scheduler initialization
     ```java
     RxJavaPlugins.setInitComputationSchedulerHandler(
         Rx2Idler.create("RxJava 2.x Computation Scheduler"));
+    RxJavaPlugins.setInitIoSchedulerHandler(
+        Rx2Idler.create("RxJava 2.x IO Scheduler"));
+    // etc...
     ```
 
  *  RxJava 1.x:


### PR DESCRIPTION
We got bitten by this recently: the documentation makes it look like the Rx2 code and the Rx 1 code are equivalent, when in fact the Rx1 version registers idling resources for all schedulers, when the Rx2 version only does it for the computation scheduler.