### PR TITLE
Fix IllegalStateException when scheduling periodic work

### DIFF
--- a/rx1-idler/src/main/java/com/squareup/rx/idler/DelegatingIdlingResourceScheduler.java
+++ b/rx1-idler/src/main/java/com/squareup/rx/idler/DelegatingIdlingResourceScheduler.java
@@ -44,7 +44,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (subscriptions.isUnsubscribed()) {
           return Subscriptions.unsubscribed();
         }
-        ScheduledWork work = createWork(action, 0L);
+        ScheduledWork work = createWork(action, 0L, 0L);
         Subscription subscription = delegateWorker.schedule(work);
         ScheduledWorkSubscription workSubscription =
             new ScheduledWorkSubscription(work, subscription);
@@ -56,7 +56,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (subscriptions.isUnsubscribed()) {
           return Subscriptions.unsubscribed();
         }
-        ScheduledWork work = createWork(action, delayTime);
+        ScheduledWork work = createWork(action, delayTime, 0L);
         Subscription subscription = delegateWorker.schedule(work, delayTime, unit);
         subscriptions.add(subscription);
         ScheduledWorkSubscription workSubscription =
@@ -71,7 +71,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (subscriptions.isUnsubscribed()) {
           return Subscriptions.unsubscribed();
         }
-        ScheduledWork work = createWork(action, initialDelay);
+        ScheduledWork work = createWork(action, initialDelay, period);
         Subscription subscription =
             delegateWorker.schedulePeriodically(work, initialDelay, period, unit);
         subscriptions.add(subscription);
@@ -101,7 +101,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
     }
   }
 
-  ScheduledWork createWork(Action0 action, long delay) {
+  ScheduledWork createWork(Action0 action, long delay, long period) {
     if (action instanceof ScheduledWork) {
       // Unwrap any re-scheduled work. We want each scheduler to get its own state machine.
       action = ((ScheduledWork) action).delegate;
@@ -111,21 +111,23 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
       startWork();
     }
     int startingState = immediate ? ScheduledWork.STATE_SCHEDULED : ScheduledWork.STATE_IDLE;
-    return new ScheduledWork(action, startingState);
+    return new ScheduledWork(action, startingState, period > 0L);
   }
 
   final class ScheduledWork extends AtomicInteger implements Action0 {
     static final int STATE_IDLE = 0; // --> STATE_RUNNING, STATE_UNSUBSCRIBED
     static final int STATE_SCHEDULED = 1; // --> STATE_RUNNING, STATE_UNSUBSCRIBED
-    static final int STATE_RUNNING = 2; // --> STATE_COMPLETED, STATE_UNSUBSCRIBED
+    static final int STATE_RUNNING = 2; // --> STATE_IDLE, STATE_COMPLETED, STATE_UNSUBSCRIBED
     static final int STATE_COMPLETED = 3; // --> STATE_UNSUBSCRIBED
     static final int STATE_UNSUBSCRIBED = 4;
 
     final Action0 delegate;
+    final boolean isPeriodic;
 
-    ScheduledWork(Action0 delegate, int startingState) {
+    ScheduledWork(Action0 delegate, int startingState, boolean isPeriodic) {
       super(startingState);
       this.delegate = delegate;
+      this.isPeriodic = isPeriodic;
     }
 
     @Override public void call() {
@@ -141,8 +143,8 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
               try {
                 delegate.call();
               } finally {
-                // Complete with a CAS to ensure we don't overwrite an unsubscribed state.
-                compareAndSet(STATE_RUNNING, STATE_COMPLETED);
+                // Change state with a CAS to ensure we don't overwrite an unsubscribed state.
+                compareAndSet(STATE_RUNNING, isPeriodic ? STATE_IDLE : STATE_COMPLETED);
                 stopWork();
               }
               return; // CAS success, we're done.

--- a/rx1-idler/src/test/java/com/squareup/rx/idler/DelegatingIdlingResourceSchedulerTest.java
+++ b/rx1-idler/src/test/java/com/squareup/rx/idler/DelegatingIdlingResourceSchedulerTest.java
@@ -81,6 +81,8 @@ public final class DelegatingIdlingResourceSchedulerTest {
     assertEquals(1, action.count());
     delegate.advanceTimeBy(500, MILLISECONDS);
     assertIdle(1);
+    delegate.advanceTimeBy(1000, MILLISECONDS);
+    assertIdle(2);
   }
 
   @Test public void runningWorkReportsBusy() {

--- a/rx2-idler/src/main/java/com/squareup/rx2/idler/DelegatingIdlingResourceScheduler.java
+++ b/rx2-idler/src/main/java/com/squareup/rx2/idler/DelegatingIdlingResourceScheduler.java
@@ -43,7 +43,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (disposables.isDisposed()) {
           return Disposables.disposed();
         }
-        ScheduledWork work = createWork(action, 0L);
+        ScheduledWork work = createWork(action, 0L, 0L);
         Disposable disposable = delegateWorker.schedule(work);
         ScheduledWorkDisposable workDisposable = new ScheduledWorkDisposable(work, disposable);
         disposables.add(workDisposable);
@@ -54,7 +54,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (disposables.isDisposed()) {
           return Disposables.disposed();
         }
-        ScheduledWork work = createWork(action, delayTime);
+        ScheduledWork work = createWork(action, delayTime, 0L);
         Disposable disposable = delegateWorker.schedule(work, delayTime, unit);
         disposables.add(disposable);
         ScheduledWorkDisposable workDisposable = new ScheduledWorkDisposable(work, disposable);
@@ -68,7 +68,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
         if (disposables.isDisposed()) {
           return Disposables.disposed();
         }
-        ScheduledWork work = createWork(action, initialDelay);
+        ScheduledWork work = createWork(action, initialDelay, period);
         Disposable disposable =
             delegateWorker.schedulePeriodically(work, initialDelay, period, unit);
         disposables.add(disposable);
@@ -97,7 +97,7 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
     }
   }
 
-  ScheduledWork createWork(Runnable action, long delay) {
+  ScheduledWork createWork(Runnable action, long delay, long period) {
     if (action instanceof ScheduledWork) {
       // Unwrap any re-scheduled work. We want each scheduler to get its own state machine.
       action = ((ScheduledWork) action).delegate;
@@ -107,21 +107,24 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
       startWork();
     }
     int startingState = immediate ? ScheduledWork.STATE_SCHEDULED : ScheduledWork.STATE_IDLE;
-    return new ScheduledWork(action, startingState);
+    return new ScheduledWork(action, startingState, period > 0L);
   }
 
   final class ScheduledWork extends AtomicInteger implements Runnable {
     static final int STATE_IDLE = 0; // --> STATE_RUNNING, STATE_DISPOSED
     static final int STATE_SCHEDULED = 1; // --> STATE_RUNNING, STATE_DISPOSED
-    static final int STATE_RUNNING = 2; // --> STATE_COMPLETED, STATE_DISPOSED
+    static final int STATE_RUNNING = 2; // --> STATE_IDLE, STATE_COMPLETED, STATE_DISPOSED
     static final int STATE_COMPLETED = 3; // --> STATE_DISPOSED
     static final int STATE_DISPOSED = 4;
 
     final Runnable delegate;
 
-    ScheduledWork(Runnable delegate, int startingState) {
+    private final boolean isPeriodic;
+
+    ScheduledWork(Runnable delegate, int startingState, boolean isPeriodic) {
       super(startingState);
       this.delegate = delegate;
+      this.isPeriodic = isPeriodic;
     }
 
     @Override public void run() {
@@ -137,8 +140,8 @@ final class DelegatingIdlingResourceScheduler extends IdlingResourceScheduler {
               try {
                 delegate.run();
               } finally {
-                // Complete with a CAS to ensure we don't overwrite a disposed state.
-                compareAndSet(STATE_RUNNING, STATE_COMPLETED);
+                // Change state with a CAS to ensure we don't overwrite a disposed state.
+                compareAndSet(STATE_RUNNING, isPeriodic ? STATE_IDLE : STATE_COMPLETED);
                 stopWork();
               }
               return; // CAS success, we're done.

--- a/rx2-idler/src/test/java/com/squareup/rx2/idler/DelegatingIdlingResourceSchedulerTest.java
+++ b/rx2-idler/src/test/java/com/squareup/rx2/idler/DelegatingIdlingResourceSchedulerTest.java
@@ -80,6 +80,8 @@ public final class DelegatingIdlingResourceSchedulerTest {
     assertEquals(1, action.count());
     delegate.advanceTimeBy(500, MILLISECONDS);
     assertIdle(1);
+    delegate.advanceTimeBy(1000, MILLISECONDS);
+    assertIdle(2);
   }
 
   @Test public void runningWorkReportsBusy() {


### PR DESCRIPTION
Addresses https://github.com/square/RxIdler/issues/6

This patch resets ScheduledWork state to idle after running if the work is meant to be periodically invoked.

(remake of https://github.com/square/RxIdler/pull/13, which I closed due to a false alarm)