### PR TITLE
Update README.md to correct testrunner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Set the wrapping functions as the delegate for handling scheduler initialization
 When that `Scheduler` is first accessed via `Schedulers`, the RxIdler function will wrap it with an
 Espresso `IdlingResource` and side-effect by registering it to the `Espresso` class.
 
-This code is most frequently put in a custom test runner's `onCreate()` method (this is called before the app's onCreate is called):
+This code is most frequently put in a custom test runner's `onCreate()` (this is called before the application `onCreate`):
 ```java
 public final class MyTestRunner extends AndroidJUnitRunner {
   @Override public void onCreate() {

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Set the wrapping functions as the delegate for handling scheduler initialization
 When that `Scheduler` is first accessed via `Schedulers`, the RxIdler function will wrap it with an
 Espresso `IdlingResource` and side-effect by registering it to the `Espresso` class.
 
-This code is most frequently put in a custom test runner's `onStart()` method:
+This code is most frequently put in a custom test runner's `onCreate()` method (this is called before the app's onCreate is called):
 ```java
 public final class MyTestRunner extends AndroidJUnitRunner {
-  @Override public void onStart() {
+  @Override public void onCreate() {
     RxJavaPlugins.setInitComputationSchedulerHandler(
         Rx3Idler.create("RxJava 3.x Computation Scheduler"));
     // etc...
-    
-    super.onStart();
+
+    super.onCreate();
   }
 }
 ```


### PR DESCRIPTION
Updates readme to use testrunner onCreate method because the onStart() method is after app:onCreate.

See
#39